### PR TITLE
fix: implement healthy quick-prep meals filter with error handling

### DIFF
--- a/src/main/kotlin/logic/usecases/GetHealthyFastFoodMealsUseCase.kt
+++ b/src/main/kotlin/logic/usecases/GetHealthyFastFoodMealsUseCase.kt
@@ -1,26 +1,43 @@
 package org.example.logic.usecases
 
 import org.example.logic.repository.MealRepository
+import org.example.model.Exceptions
 import org.example.model.Meal
 
 class GetHealthyFastFoodMealsUseCase(
     private val mealRepository: MealRepository
 ) {
     fun getHealthyMeals(): List<Meal> {
-        return mealRepository.getAllMeals()
-            .filter(::isFastToPrepareMeal)
-            .sorted()
+        val allMeals = try {
+            mealRepository.getAllMeals()
+        } catch (e: Exception) {
+            throw Exceptions.NoFoodFoundException("Failed to retrieve meals from repository: ${e.message}")
+        }
+
+        if (allMeals.isEmpty()) {
+            throw Exceptions.NoMealsFoundException()
+        }
+
+        val healthyFastMeals = allMeals.filter(::isFastToPrepareMeal)
+
+        if (healthyFastMeals.isEmpty()) {
+            throw Exceptions.NoMealsFound("No healthy meals found that can be prepared in $MAX_PREP_TIME_MINUTES minutes or less")
+        }
+
+        return healthyFastMeals.sorted()
     }
 
     private fun isFastToPrepareMeal(meal: Meal): Boolean {
-        if (meal.minutes == null)
+        if (meal.minutes == null) {
             return false
+        }
 
         return meal.minutes <= MAX_PREP_TIME_MINUTES
     }
 
     companion object {
         const val MAX_PREP_TIME_MINUTES = 15
-        const val LOW_NUTRITION_PERCENTILE = 0.25 // lowest 25%
     }
 }
+class NoMealsFound(message: String = "No meals found matching the specified criteria.") : Exceptions(message)
+class MealNotFoundException(message: String = "The requested meal could not be found in the repository.") : Exceptions(message)

--- a/src/main/kotlin/logic/usecases/GetHealthyFastFoodMealsUseCase.kt
+++ b/src/main/kotlin/logic/usecases/GetHealthyFastFoodMealsUseCase.kt
@@ -8,24 +8,13 @@ class GetHealthyFastFoodMealsUseCase(
     private val mealRepository: MealRepository
 ) {
     fun getHealthyMeals(): List<Meal> {
-        val allMeals = try {
-            mealRepository.getAllMeals().also { meals ->
-                if (meals.isEmpty()) {
-                    throw Exceptions.NoMealsFoundException()
-                }
-            }
-        } catch (e: Exception) {
-            throw Exceptions.NoFoodFoundException("Failed to retrieve meals from repository: ${e.message}")
-        }
-
-        return allMeals
+        return mealRepository.getAllMeals()
             .filter(::isFastToPrepareMeal)
-            .also { healthyFastMeals ->
-                if (healthyFastMeals.isEmpty()) {
-                    throw Exceptions.NoMealsFound("No healthy meals found that can be prepared in $MAX_PREP_TIME_MINUTES minutes or less")
-                }
-            }
             .sorted()
+            .takeIf { it.isNotEmpty()}?:
+            throw Exceptions.NoMealsFound("No healthy meals found that can be prepared in $MAX_PREP_TIME_MINUTES minutes or less")
+
+
     }
 
     private fun isFastToPrepareMeal(meal: Meal): Boolean {

--- a/src/main/kotlin/logic/usecases/GetHealthyFastFoodMealsUseCase.kt
+++ b/src/main/kotlin/logic/usecases/GetHealthyFastFoodMealsUseCase.kt
@@ -39,5 +39,3 @@ class GetHealthyFastFoodMealsUseCase(
         const val MAX_PREP_TIME_MINUTES = 15
     }
 }
-class NoMealsFound(message: String = "No meals found matching the specified criteria.") : Exceptions(message)
-class MealNotFoundException(message: String = "The requested meal could not be found in the repository.") : Exceptions(message)

--- a/src/main/kotlin/model/Exceptions.kt
+++ b/src/main/kotlin/model/Exceptions.kt
@@ -2,8 +2,8 @@ package org.example.model
 
 sealed class Exceptions(message: String) : Exception(message) {
     class InvalidDateFormat(message: String) : Exceptions(message)
-    class NoMealsFound(message: String) : Exceptions(message)
-    class MealNotFoundException(message: String = "There is not meals") : Exceptions(message)
+    class NoMealsFound(message: String = "No meals found matching the specified criteria.") : Exceptions(message)
+    class MealNotFoundException(message: String = "The requested meal could not be found in the repository.") : Exceptions(message)
     class KeywordNotFoundException(val keyword: String) : Exception("No matches found for the text: $keyword")
     class NoFoodFoundException(message: String = "No meals available in the repository") :
         RuntimeException(message)
@@ -14,5 +14,4 @@ sealed class Exceptions(message: String) : Exception(message) {
     class BlankKeywordException : Exception("You can't search by blank value")
     class InvalidInputException(message: String) : Exception(message)
     class NoMealsFoundException : Exception("No meals found matching your criteria.")
-
 }


### PR DESCRIPTION

This pull request refactors the `GetHealthyFastFoodMealsUseCase` class to improve error handling and ensure meaningful exceptions are thrown when issues arise. It also removes unused constants and adds new exception classes for better error specificity.

### Error handling improvements:
* Wrapped the call to `mealRepository.getAllMeals()` in a `try-catch` block to throw a `NoFoodFoundException` when an exception occurs while retrieving meals.
* Added checks to throw `NoMealsFoundException` if the retrieved meal list is empty and `NoMealsFound` if no healthy fast meals are found.

### Code cleanup and additions:
* Removed the unused constant `LOW_NUTRITION_PERCENTILE`.
* Added new exception classes: `NoMealsFound` and `MealNotFoundException`, both extending `Exceptions`, to improve error specificity.