### PR TITLE
fix: import package name

### DIFF
--- a/src/test/kotlin/presentation/HealthyFastFoodMealsUITest.kt
+++ b/src/test/kotlin/presentation/HealthyFastFoodMealsUITest.kt
@@ -1,4 +1,4 @@
-package org.example.presentation
+package presentation
 
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
@@ -8,6 +8,7 @@ import io.mockk.verifySequence
 import logic.usecases.createMeal
 import org.example.logic.usecases.GetHealthyFastFoodMealsUseCase
 import org.example.model.Exceptions
+import org.example.presentation.HealthyFastFoodMealsUI
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows


### PR DESCRIPTION
This pull request makes minor adjustments to the `HealthyFastFoodMealsUITest` file, primarily involving package restructuring and import updates.

Changes include:

### Package restructuring:
* Updated the package declaration from `org.example.presentation` to `presentation` to align with the new project structure. (`[src/test/kotlin/presentation/HealthyFastFoodMealsUITest.ktL1-R1](diffhunk://#diff-2dc574686cc8af7af6cdf2c57a5d9565c1a6dc625d59093cb3569ee0cb1eaf04L1-R1)`)

### Import updates:
* Added an import for `org.example.presentation.HealthyFastFoodMealsUI` to ensure the required class is available for testing. (`[src/test/kotlin/presentation/HealthyFastFoodMealsUITest.ktR11](diffhunk://#diff-2dc574686cc8af7af6cdf2c57a5d9565c1a6dc625d59093cb3569ee0cb1eaf04R11)`)